### PR TITLE
Add app-crypt/gcr dependency to accountsservice

### DIFF
--- a/sys-apps/accountsservice/accountsservice-0.6.35.ebuild
+++ b/sys-apps/accountsservice/accountsservice-0.6.35.ebuild
@@ -28,6 +28,7 @@ RDEPEND="
 	!systemd? ( sys-auth/consolekit )
 "
 DEPEND="${RDEPEND}
+	app-crypt/gcr
 	dev-libs/libxslt
 	dev-util/gdbus-codegen
 	>=dev-util/gtk-doc-am-1.15


### PR DESCRIPTION
I encountered error in configuration step when I was building this package(gcr-base-3 can't be found). I emerged app-crypt/gcr and after that building was succeeded.
