### PR TITLE
Update gnome-desktop-3.11.90.ebuild

### DIFF
--- a/gnome-base/gnome-desktop/gnome-desktop-3.11.90.ebuild
+++ b/gnome-base/gnome-desktop/gnome-desktop-3.11.90.ebuild
@@ -10,7 +10,7 @@ inherit gnome2
 DESCRIPTION="Libraries for the gnome desktop that are not part of the UI"
 HOMEPAGE="https://git.gnome.org/browse/gnome-desktop"
 SRC_URI="${SRC_URI}
-	https://launchpad.net/~gnome3-team/+archive/gnome3-staging/+files/gnome-desktop3_3.11.4-0ubuntu1%7Etrusty1.debian.tar.gz"
+	https://launchpad.net/~gnome3-team/+archive/gnome3-staging/+files/gnome-desktop3_3.11.90-0ubuntu1%7Etrusty3.debian.tar.gz"
 
 LICENSE="GPL-2+ FDL-1.1+ LGPL-2+"
 SLOT="3/8" # subslot = libgnome-desktop-3 soname version


### PR DESCRIPTION
wrong name of package for download
