### PR TITLE
Update gtk+-3.12.2.ebuild

### DIFF
--- a/x11-libs/gtk+/gtk+-3.12.2.ebuild
+++ b/x11-libs/gtk+/gtk+-3.12.2.ebuild
@@ -26,7 +26,7 @@ REQUIRED_USE="
 
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 SRC_URI="${SRC_URI}
-	https://launchpad.net/~gnome3-team/+archive/gnome3-staging/+files/gtk%2B3.0_3.12.2-0ubuntu1%7Etrusty1.debian.tar.xz"
+	https://launchpad.net/~gnome3-team/+archive/gnome3-staging/+files/gtk%2B3.0_3.12.2-0ubuntu4%7Etrusty1.debian.tar.xz"
 
 # FIXME: introspection data is built against system installation of gtk+:3
 # NOTE: cairo[svg] dep is due to bug 291283 (not patched to avoid eautoreconf)


### PR DESCRIPTION
Fixes 404 error when trying to download GTK+ 3.12.2 from launchpad. Bumps 1 to 4.
