### PR TITLE
Update plank-0.11.89.ebuild

### DIFF
--- a/x11-misc/plank/plank-0.11.89.ebuild
+++ b/x11-misc/plank/plank-0.11.89.ebuild
@@ -21,6 +21,7 @@ CDEPEND="
 	dev-libs/glib:2
 	dbus? ( dev-libs/libdbusmenu[gtk3] )
 	dev-libs/libgee:0.8
+	>=gnome-base/gnome-menus-3.32.0
 	>=x11-libs/bamf-0.2.92
 	>=x11-libs/cairo-1.10
 	>=x11-libs/gdk-pixbuf-2.26.0


### PR DESCRIPTION
Plank failed to build due to missing dependency. I emerged gnome-base/gnome-menus, and x11-misc/plank sucessfully emerged.

```
checking for GNOMEMENU3... no
configure: error: Package requirements (libgnome-menu-3.0) were not met:

Package 'libgnome-menu-3.0', required by 'virtual:world', not found
```